### PR TITLE
fixture: state must be an integer

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ http.createServer(function(request, response) {
                 var state = fs.readFileSync(nukiId + ".state", "UTF-8");
                 console.log(theUrlPathname + "---" + nukiId + "---" + state);
                 responseBody = {
-                    state: state,
+                    state: parseInt(state),
                     stateName: "Status: " + state,
                     batteryCritical: false,
                     success: "true"


### PR DESCRIPTION
According to the API spec the state value is an integer. See page 4 of https://nuki.io/wp-content/uploads/2016/04/Bridge-API-v1.02.pdf
